### PR TITLE
Disabling LawOfDemeter PMD

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,5 +66,5 @@ dependencies {
 check.doLast {
     project.tasks.getByName("checkstyle").execute()
     project.tasks.getByName("findbugs").execute()
-    //project.tasks.getByName("pmd").execute()
+    project.tasks.getByName("pmd").execute()
 }

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -63,6 +63,7 @@
     <rule ref="rulesets/java/coupling.xml">
         <exclude name="CouplingBetweenObjects"/>
         <exclude name="ExcessiveImports"/>
+        <exclude name="LawOfDemeter"/>
     </rule>
 
     <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects">


### PR DESCRIPTION
some info: http://pmd.sourceforge.net/pmd-5.2.3/pmd-java/rules/java/coupling.html#LawOfDemeter

Enabling PMD on grade, disabling LawOfDemeter because there's no sense the kind of errors that shows on android.


