### PR TITLE
Upgrading gradle to 2.1.0. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'io.fabric.tools:gradle:1.+'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
         // NOTE: Do not place your application dependencies here; they belong
@@ -22,9 +22,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots"
-        }
     }
 }
 


### PR DESCRIPTION
* Upgrading gradle to 2.1.0. 
* Removing snapshot repository, since we are not using dagger snapshots anymore.